### PR TITLE
Adds PHP tag only when code does not start with `<`

### DIFF
--- a/ob-phpstan.el
+++ b/ob-phpstan.el
@@ -49,7 +49,9 @@
 (defun org-babel-execute:phpstan (body params)
   "Org mode fish evaluate function"
   (let ((tmp-file (org-babel-temp-file "phpstan-" ".php"))
-        (body (concat "<?php\n" body))
+        (body (if (string-prefix-p "<" body)
+                  body
+                (concat "<?php " body)))
         (level (or (cdr (assoc :level params)) org-babel-phpstan-level)))
     (with-temp-file tmp-file (insert (org-babel-expand-body:generic body params)))
     (org-babel-eval (format "%s analyze %s --level %s --no-progress"


### PR DESCRIPTION
If the input code starts with `<?php`, `<?=` or an HTML tag (like `<html>`), do not add `<?php`. And don't put a line break right after the `<?php ` so that the line number printed in the error matches the line of code.